### PR TITLE
docs: refresh auth and telemetry examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,15 +179,15 @@ use Arcp\Envelope\Envelope;
 use Arcp\Messages\Execution\JobProgress;
 use Arcp\Messages\Execution\ResultChunk;
 use Arcp\Messages\Telemetry\EventEmit;
-use Arcp\Messages\Telemetry\LogRecord;
-use Arcp\Messages\Telemetry\Metric;
+use Arcp\Messages\Telemetry\LogEvent;
+use Arcp\Messages\Telemetry\MetricEvent;
 
 $client->subscribe(
     ['session_id' => [(string) $client->session->sessionId]],
     static function (Envelope $env) use ($client): void {
         match (true) {
-            $env->payload instanceof LogRecord     => printf("[log] %s\n", $env->payload->message),
-            $env->payload instanceof Metric        => printf("[metric] %s=%s %s\n", $env->payload->name, $env->payload->value, $env->payload->unit ?? ''),
+            $env->payload instanceof LogEvent      => printf("[log] %s\n", $env->payload->message),
+            $env->payload instanceof MetricEvent   => printf("[metric] %s=%s %s\n", $env->payload->name, $env->payload->value, $env->payload->unit),
             $env->payload instanceof JobProgress   => printf("[progress %d%%] %s\n", $env->payload->percent, $env->payload->message ?? ''),
             $env->payload instanceof ResultChunk   => $client->resultChunks->push($env->payload),
             $env->payload instanceof EventEmit     => printf("[event] %s\n", $env->payload->eventType),
@@ -204,13 +204,13 @@ Request capabilities, a budget, and an expiry; read budget-remaining metrics as 
 ```php
 use Arcp\Envelope\Envelope;
 use Arcp\Errors\BudgetExhaustedException;
-use Arcp\Messages\Telemetry\Metric;
+use Arcp\Messages\Telemetry\MetricEvent;
 
 $client->subscribe(
     ['types' => ['metric']],
     static function (Envelope $env): void {
-        if ($env->payload instanceof Metric && $env->payload->name === 'cost.budget.remaining') {
-            printf("budget remaining: %.2f %s\n", $env->payload->value, $env->payload->unit ?? '');
+        if ($env->payload instanceof MetricEvent && $env->payload->name === 'cost.budget.remaining') {
+            printf("budget remaining: %.2f %s\n", $env->payload->value, $env->payload->unit);
         }
     },
 );

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -26,7 +26,7 @@ principal. `NoneAuth` accepts anonymous sessions.
 
 ```php
 $runtime = new ARCPRuntime(
-    authRouter: new AuthRouter([new BearerAuth('secret', principal: 'alice')]),
+    authRouter: new AuthRouter([new BearerAuth(['secret' => 'alice'])]),
 );
 ```
 
@@ -37,7 +37,7 @@ Implement `Arcp\Auth\AuthScheme`:
 ```php
 final class HeaderAuth implements AuthScheme
 {
-    public function scheme(): string
+    public function name(): string
     {
         return 'bearer';
     }
@@ -45,8 +45,8 @@ final class HeaderAuth implements AuthScheme
     public function verify(Auth $auth, PeerInfo $peer): AuthResult
     {
         return $auth->token === 'secret'
-            ? AuthResult::accepted('alice')
-            : AuthResult::rejected('bad token');
+            ? AuthResult::accept('alice')
+            : AuthResult::reject('bad token');
     }
 }
 ```

--- a/samples/submit-and-stream/main.php
+++ b/samples/submit-and-stream/main.php
@@ -9,11 +9,11 @@ function streamJobEvents(): array
 {
     return [
         ['type' => 'job.started', 'payload' => ['phase' => 'start']],
-        ['type' => 'log.event', 'payload' => ['level' => 'info', 'message' => 'planning']],
-        ['type' => 'stream.chunk', 'payload' => ['kind' => 'thought', 'content' => 'choose tool']],
-        ['type' => 'metric.event', 'payload' => ['name' => 'cost.usd', 'value' => 0.03]],
+        ['type' => 'log', 'payload' => ['level' => 'info', 'message' => 'planning']],
+        ['type' => 'thought', 'payload' => ['text' => 'choose tool']],
+        ['type' => 'metric', 'payload' => ['name' => 'cost.usd', 'value' => 0.03, 'unit' => 'USD']],
         ['type' => 'tool.result', 'payload' => ['tool' => 'search', 'ok' => true]],
-        ['type' => 'artifact.ref', 'payload' => ['artifact_id' => 'art_report']],
+        ['type' => 'artifact.ref', 'payload' => ['uri' => 'art_report']],
         ['type' => 'job.completed', 'payload' => ['value' => 'done']],
     ];
 }


### PR DESCRIPTION
Updates the PHP auth guide to the current auth API and refreshes the README telemetry snippets to use the current event/message classes and wire names.