### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,18 @@ jobs:
         if: hashFiles('.php-cs-fixer.dist.php', '.php-cs-fixer.php') != ''
         run: vendor/bin/php-cs-fixer fix --dry-run --diff
 
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit
+      - name: Run PHPUnit (with Clover coverage)
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml
+
+      # Non-blocking: a Codecov outage cannot break CI.
+      - name: Upload coverage to Codecov
+        # codecov/codecov-action v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          fail_ci_if_error: false
+          flags: unittests
+          files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test artifacts on failure
         if: failure()


### PR DESCRIPTION
## Summary
- Emit Clover XML from PHPUnit (PCOV is already enabled, source is already configured in `phpunit.xml`).
- Upload `coverage.xml` to Codecov.
- `fail_ci_if_error: false` so a Codecov outage cannot break CI.

## Pre-merge action required
- Add `CODECOV_TOKEN` as a repo secret (`gh secret set CODECOV_TOKEN --repo agentruntimecontrolprotocol/php-sdk`).
- Activate the repo at [app.codecov.io](https://app.codecov.io/gh/agentruntimecontrolprotocol/php-sdk).

## Test plan
- [ ] Merge, confirm coverage uploads on next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated testing infrastructure with code coverage tracking and reporting capabilities to improve code quality monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentruntimecontrolprotocol/php-sdk/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->