### PR TITLE
docs: fix CI badge URL to point at test.yml workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://packagist.org/packages/arcp/arcp"><img alt="Packagist" src="https://img.shields.io/packagist/v/arcp/arcp.svg"></a>
-  <a href="https://github.com/agentruntimecontrolprotocol/php-sdk/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/agentruntimecontrolprotocol/php-sdk/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://github.com/agentruntimecontrolprotocol/php-sdk/actions/workflows/test.yml"><img alt="CI" src="https://github.com/agentruntimecontrolprotocol/php-sdk/actions/workflows/test.yml/badge.svg"></a>
   <a href="https://packagist.org/packages/arcp/arcp"><img alt="PHP version" src="https://img.shields.io/packagist/php-v/arcp/arcp.svg"></a>
   <a href="https://github.com/agentruntimecontrolprotocol/spec/blob/main/docs/draft-arcp-1.1.md"><img alt="ARCP" src="https://img.shields.io/badge/ARCP-v1.1%20draft-blue"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-lightgrey"></a>


### PR DESCRIPTION
## Summary

- Badge `src` referenced `ci.yml` but the workflow file is `test.yml`, so the README badge rendered as "no status."

## Test plan

- [x] Markdown render check: badge now points at the real workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI status badge reference in documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentruntimecontrolprotocol/php-sdk/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->